### PR TITLE
Add jinja template CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ fie_lonet_switch --help
   fie_lonet_switch clear_group mygroup
   ```
 
+- List all configured Jinja template paths:
+
+  ```sh
+  fie_lonet_switch jinjas list
+  ```
+
+- Add a Jinja template path:
+
+  ```sh
+  fie_lonet_switch jinjas add /path/to/template.jinja
+  ```
+
+- Delete a Jinja template path:
+
+  ```sh
+  fie_lonet_switch jinjas delete /path/to/template.jinja
+  ```
+
 ## Switch Scripts
 
 You can create switch scripts to automatic switcing of things based when you switch state.

--- a/fie_lonet_switch/cli.py
+++ b/fie_lonet_switch/cli.py
@@ -1,6 +1,12 @@
 import click
 from fie_lonet_switch.switcher import do_switch
-from fie_lonet_switch.database import SwitchStateDB, get_switch_state_transaction, compact_db_transaction, clear_group_transaction
+from fie_lonet_switch.database import (
+    SwitchStateDB,
+    get_switch_state_transaction,
+    compact_db_transaction,
+    clear_group_transaction,
+    JinjaTemplate,
+)
 
 @click.group()
 def main():
@@ -64,6 +70,66 @@ def clear_group(group):
         click.echo(f"All switch state changes for group '{group}' have been deleted.")
     except Exception as e:
         click.echo(f"Error clearing group '{group}': {e}")
+    finally:
+        db.close()
+
+@main.group()
+def jinjas():
+    """Manage jinja template paths."""
+    pass
+
+
+@jinjas.command("list")
+def list_jinjas():
+    """List the stored jinja template paths."""
+    db = SwitchStateDB()
+    try:
+        templates = db.get_all_jinja_templates()
+        for tmpl in templates:
+            click.echo(tmpl.path)
+    finally:
+        db.close()
+
+
+@jinjas.command("add")
+@click.argument("path")
+def add_jinja(path):
+    """Add a jinja template path."""
+    db = SwitchStateDB()
+    try:
+        db.begin()
+        try:
+            # Check for existing path; ignore if present
+            db.get_jinja_template_by_path(path)
+            db.rollback()
+        except LookupError:
+            tmpl = JinjaTemplate(path=path)
+            db.create_jinja_template(tmpl)
+            db.commit()
+        click.echo(f"Added {path}")
+    except Exception as e:
+        db.rollback()
+        click.echo(f"Error adding template '{path}': {e}")
+    finally:
+        db.close()
+
+
+@jinjas.command("delete")
+@click.argument("path")
+def delete_jinja(path):
+    """Remove a jinja template path."""
+    db = SwitchStateDB()
+    try:
+        db.begin()
+        try:
+            db.delete_jinja_template_by_path(path)
+        except LookupError:
+            pass
+        db.commit()
+        click.echo(f"Deleted {path}")
+    except Exception as e:
+        db.rollback()
+        click.echo(f"Error deleting template '{path}': {e}")
     finally:
         db.close()
 

--- a/fie_lonet_switch/database.py
+++ b/fie_lonet_switch/database.py
@@ -225,6 +225,20 @@ class SwitchStateDB:
         if cur.rowcount == 0:
             raise LookupError(f"JinjaTemplate with id {id} not found for deletion.")
 
+    def get_jinja_template_by_path(self, path: str) -> 'JinjaTemplate':
+        cur = self.conn.cursor()
+        cur.execute('SELECT id, path FROM jinja_templates WHERE path = ?', (path,))
+        row = cur.fetchone()
+        if row:
+            return JinjaTemplate(id=row[0], path=row[1])
+        raise LookupError(f"JinjaTemplate with path {path} not found.")
+
+    def delete_jinja_template_by_path(self, path: str) -> None:
+        cur = self.conn.cursor()
+        cur.execute('DELETE FROM jinja_templates WHERE path = ?', (path,))
+        if cur.rowcount == 0:
+            raise LookupError(f"JinjaTemplate with path {path} not found for deletion.")
+
 def switch_change_transaction(db: SwitchStateDB, switch_to:Literal['lo', 'net'], group:str = "*", locale:str = "") -> None:
     """
     Perform a switch change transaction.


### PR DESCRIPTION
## Summary
- support CRUD operations on Jinja template paths
- expose jinja template management commands in CLI
- document jinja template commands in README

## Testing
- `python -m py_compile fie_lonet_switch/*.py`
- `pytest -q` *(fails: command not found)*