### PR TITLE
Support group in jinja templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ fie_lonet_switch --help
   fie_lonet_switch jinjas add /path/to/template.jinja
   ```
 
+  Add a template path for a specific group:
+
+  ```sh
+  fie_lonet_switch jinjas add /path/to/other_template.jinja mygroup
+  ```
+
 - Delete a Jinja template path:
 
   ```sh


### PR DESCRIPTION
## Summary
- add `group` field to `JinjaTemplate` model and database
- migrate existing databases to add `group_name` column
- show and set groups with `fie_lonet_switch jinjas` commands

## Testing
- `pytest -q` *(fails: command not found)*