### PR TITLE
Handle jinja templates on switch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ dependencies = [
     "click>=8.0.0",
     "textual>=0.40.0",
     "rumps>=0.4.0",
-    "pydantic>=2.0.0"
+    "pydantic>=2.0.0",
+    "jinja2>=3.0.0"
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- render jinja templates stored in the database after a switch
- add `do_switch_jinjas_in_db` helper
- include Jinja2 dependency in project configuration

## Testing
- `python -m compileall -q fie_lonet_switch`