### PR TITLE
Fix: Make tray icon dependency (rumps) macOS-specific

### DIFF
--- a/fie_lonet_switch/tray.py
+++ b/fie_lonet_switch/tray.py
@@ -1,0 +1,11 @@
+import sys
+
+def main():
+    print("The FIE Lonet Switch tray application is only available on macOS.", file=sys.stderr)
+    # Or, alternatively, use a logger if the project has one configured.
+    # Or, do nothing silently. For now, a print statement is fine.
+
+if __name__ == "__main__":
+    # This part is optional, as tray_entry.py calls tray.main() directly.
+    # However, it's good practice to include it.
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.8"
 dependencies = [
     "click>=8.0.0",
     "textual>=0.40.0",
-    "rumps>=0.4.0",
+    "rumps>=0.4.0; sys_platform == 'darwin'",
     "pydantic>=2.0.0",
     "jinja2>=3.0.0"
 ]


### PR DESCRIPTION
The `rumps` library, used for the system tray icon, is macOS-only and caused installation issues on other platforms.

This change addresses the issue by:
1. Modifying `pyproject.toml` to make `rumps` a conditional dependency, only to be installed when `sys_platform == 'darwin'`.
2. Ensuring the application handles the absence of `rumps` gracefully. The `fie_lonet_switch/tray_entry.py` already had platform-specific dispatching logic. The `fie_lonet_switch/tray.py` (for non-Mac) has been updated to print a message indicating the tray functionality is macOS-specific, instead of trying to import or use `rumps`.

I confirmed that `rumps` is not installed on non-Mac systems and the tray application entry point runs without error, displaying the appropriate message.